### PR TITLE
docs: add Global Dev Docs Standard link and cross-repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,19 @@ bun run eval
 
 - Queue runner support is not implemented.
 - Title parsing is only a legacy discovery fallback; registry state is the source of truth for agent identity.
+
+## 📚 Documentation
+
+This repository follows the [Global Dev Docs Standard](https://github.com/OpenSIN-AI/Global-Dev-Docs-Standard).
+
+For contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
+For security policy, see [SECURITY.md](SECURITY.md).
+For the complete OpenSIN ecosystem, see [OpenSIN-AI Organization](https://github.com/OpenSIN-AI).
+
+## 🔗 See Also
+
+- [OpenSIN Core](https://github.com/OpenSIN-AI/OpenSIN) — Main platform
+- [OpenSIN-Code](https://github.com/OpenSIN-AI/OpenSIN-Code) — CLI
+- [OpenSIN-backend](https://github.com/OpenSIN-AI/OpenSIN-backend) — Backend
+- [OpenSIN-Infrastructure](https://github.com/OpenSIN-AI/OpenSIN-Infrastructure) — Deploy
+- [Global Dev Docs Standard](https://github.com/OpenSIN-AI/Global-Dev-Docs-Standard) — Docs


### PR DESCRIPTION
This PR adds the Global Dev Docs Standard link and cross-repo links to the README.